### PR TITLE
bug Fix on NAME TAGS page for only Printed Pages

### DIFF
--- a/client/app/name_tags/name_tags.controller.coffee
+++ b/client/app/name_tags/name_tags.controller.coffee
@@ -40,16 +40,26 @@ angular.module 'nbaAgcAdminApp'
 .controller 'LNameTagsCtrl', ($scope, RegisteredUser, $state, printed, $localStorage) ->
   $scope.perPage = $localStorage.usersPerPage or 50
   $scope.currentPage = 1
+  $scope.currentPageUnprinted = 1
   $scope.pageSizes = [25, 50, 100]
   $scope.printed = printed
   $scope.term = ''
+  $scope.checkUnprinted = false
 
   $scope.selection = []
   $scope.selectedAll = false
 
+  $scope.toggleCheckUnprinted = ->
+#    $scope.checkUnprinted = !$scope.checkUnprinted
+    $scope.pageChanged()
+
   $scope.pageChanged = ->
-    $localStorage.usersPerPage = $scope.perPage
-    $scope.load $scope.currentPage
+    if $scope.checkUnprinted is true
+      $localStorage.usersPerPage = $scope.perPage
+      $scope.loadUnprinted $scope.currentPage
+    else
+      $localStorage.usersPerPage = $scope.perPage
+      $scope.load $scope.currentPage
 
   $scope.checkAll = ->
     $scope.selection = []
@@ -75,7 +85,10 @@ angular.module 'nbaAgcAdminApp'
       $scope.total = parseInt headers "total_found"
       $scope.pages = Math.ceil($scope.total / $scope.perPage)
 
-  $scope.load 1
+  if $scope.checkUnprinted is true
+    $scope.loadUnprinted 1
+  else
+    $scope.load 1
 
   $scope.doLookup = ->
     RegisteredUser.query name: $scope.term

--- a/client/app/name_tags/name_tags_staged.html
+++ b/client/app/name_tags/name_tags_staged.html
@@ -14,7 +14,7 @@
                 <div class="input-group button-group">
                     <select class="form-control" ng-model="perPage" ng-options="item for item in pageSizes"
                             ng-change="pageChanged()"></select>
-                    <input class="btn btn-primary" type="radio" ng-click="loadUnprinted(1)"> ONLY UNPRINTED
+                    <input class="btn btn-primary" type="checkbox" ng-click="toggleCheckUnprinted()" ng-model="checkUnprinted"> ONLY UNPRINTED
                 </div>
             </div>
             <div class="text-center">


### PR DESCRIPTION
**Fixed a Bug On the Name Tags Page**

If the checkbox for # **_only printed_** is selected, navigating to the next page will not load based on the criteria
